### PR TITLE
Fix team city

### DIFF
--- a/app/models/payload_adapters/team_city_build_complete.rb
+++ b/app/models/payload_adapters/team_city_build_complete.rb
@@ -3,15 +3,17 @@ module PayloadAdapters
   class TeamCityBuildComplete < Base
 
     def user
-      @user ||= User.find_by_name(triggered_by)
+      @user ||= Services::Github.find_by_username(triggered_by).try(:user)
+      puts "Reached TeamCityBuildComplete #{@user}"
+      @user
     end
 
     def triggered_by
-      payload[:build][:triggeredBy]
+      payload[:build_triggered_by]
     end
 
     def green?
-      payload[:build][:buildResult] == "success"
+      payload[:build_result] == "success"
     end
 
   end


### PR DESCRIPTION
Changed the payload adapter for team city to respond to my custom reporting instead of the crappy plugin.

Also made it clan friendly.
