### PR TITLE
Reduce the size of the payload when storing github pushes.

### DIFF
--- a/app/models/payload_adapters/github_push.rb
+++ b/app/models/payload_adapters/github_push.rb
@@ -8,7 +8,7 @@ module PayloadAdapters
 
     def github_username
       username = payload[:pusher][:name] rescue nil
-      username || payload[:committers].first rescue nil
+      username || payload[:committers].to_a.sort_by(&:last).last.first rescue nil
     end
 
     def payload=(value)
@@ -26,6 +26,13 @@ module PayloadAdapters
 
       @payload.delete("commits")
       @payload.delete("head_commit")
+
+      # Tally the committers
+      @payload["committers"] = @payload["committers"].inject(Hash.new) do |totals, committer|
+      	totals[committer] ||= 0
+      	totals[committer] += 1
+      	totals
+      end
     end
 
   end


### PR DESCRIPTION
Truncates the payload to just the names of the authors instead of all the commit messages, files changed, etc. Reduces a 100kb JSON file to under 1k.

This is what it looks like now:

``` ruby
{"ref"=>"refs/heads/visual-refresh",
 "after"=>"ac4acefc9bfe6b6f467688ebc10e95e4c51c2552",
 "before"=>"e1f888697d78b2f933851a6a8af274a6ec6e3782",
 "created"=>false,
 "deleted"=>false,
 "forced"=>false,
 "compare"=>
  "https://github.com/envato/marketplace/compare/e1f888697d78...ac4acefc9bfe",
 "repository"=>
  {"id"=>28023,
   "name"=>"marketplace",
   "url"=>"https://github.com/envato/marketplace",
   "description"=>"Ideas.find(:all).each { |idea| Site.create!(idea) }",
   "homepage"=>"http://activeden.net",
   "watchers"=>5,
   "stargazers"=>5,
   "forks"=>0,
   "fork"=>false,
   "size"=>921627,
   "owner"=>{"name"=>"envato", "email"=>nil},
   "private"=>true,
   "open_issues"=>32,
   "has_issues"=>true,
   "has_downloads"=>true,
   "has_wiki"=>true,
   "language"=>"Ruby",
   "created_at"=>1214274126,
   "pushed_at"=>1391141706,
   "master_branch"=>"master",
   "organization"=>"envato"},
 "pusher"=>{"name"=>"bensmithett", "email"=>"bsmithett@gmail.com"},
 "committers"=>
  {"bensmithett"=>2,
   "damirkotoric"=>44,
   "elseano"=>45,
   "gstamp"=>32,
   "spickermann"=>25,
   "eadz"=>11,
   "orien"=>2,
   "madlep"=>2,
   "stevehodgkiss"=>4,
   "irakeshraut"=>3}}
```
