### PR TITLE
Load Dotenv as early as possible in Development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,11 @@ if defined?(Bundler)
   # Bundler.require *Rails.groups(:assets => %w(development test))
   # If you want your assets lazily compiled in production, use this line
   Bundler.require(:default, Rails.env)
+
+  # Allow .env variables to be available at boot time in Development
+  if Rails.env == "development"
+    Dotenv::Railtie.load
+  end
 end
 
 # Note, .dev TLD won't be accepted by Google OAuth callbacks, you'll need


### PR DESCRIPTION
Unfortunately, [this](https://github.com/AeroCross/highlander/blob/cea2a7028e46bfdadbedf7c7093ad36753b96e64/config/application.rb#L23) line isn't working.

The reason is that, [according to the documentation](https://github.com/bkeepers/dotenv#note-on-load-order), Dotenv isn't loaded when this file is parsed. This means that the `SITE_ROOT` in here will _always_ be `hilanderlocal.com:3000`.

The problem is that if you set up your `HILANDER_ROOT` differently in your `.env` file, you will never be able to load the site correctly, because you're effectively using two different `SITE_ROOT` — one in `application.rb` and the another one after the application is loaded.

This is extremely confusing when setting up the project, so let's fix it!

### How to reproduce the bug

- Checkout `master`
- Create a `.env` file
- Define `HILANDER_ROOT` there with a value different than `hilanderlocal.com:3000`
- Start a `rails server`
- Try to load the default clan
- Watch it fail miserably (because it will still think that the SITE_ROOT is still `hilanderlocal.com:3000`)

Then...

- Checkout this branch
- Restart the server
- Watch it succeed with the root that you defined

### CC:

@ejoubaud