### PR TITLE
Fix email paths

### DIFF
--- a/app/views/shared/_rankee.html.erb
+++ b/app/views/shared/_rankee.html.erb
@@ -1,4 +1,4 @@
-<%= link_to user_path(rankee.user) do %>
+<%= link_to user_url(rankee.user) do %>
   <p class="rank"><%= (rankee.index) %></p>
 
   <ul class="details">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,6 +13,9 @@ Highlander::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # Make sure there's a defined host for URL's
+  config.action_mailer.default_url_options = { :host => SITE_ROOT }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
As we all know, emails have been broken for a while now.

![screen shot 2016-06-06 at 10 17 00 am](https://cloud.githubusercontent.com/assets/942337/15809236/e78796f8-2bcf-11e6-95b1-c5d3177b3809.png)

From my investigation, I see that we're using paths for a _shared_ partial — this is OK if this is only used in the context of the application, but not for external resources like email. In this case, we need to send emails using the full URL.

This changes achieves that!