### PR TITLE
Fix emails for realsies!

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,7 +8,7 @@ class UserMailer < ActionMailer::Base
     @clan = bounties.first.clan
 
     @stylesheet = 'bounties.css'
-    mail to: user.primary_email, subject: "[hilander] New bounties offered in #{@clan.name}!"   
+    mail to: user.primary_email, subject: "[hilander] New bounties offered in #{@clan.name}!"
   end
 
   def leaderboard(user, clan)

--- a/app/models/clan.rb
+++ b/app/models/clan.rb
@@ -19,7 +19,7 @@ class Clan < ActiveRecord::Base
 
   def set_integration_config(integration_class, config)
     hash = self.configuration_settings.dup
-    
+
     if config.values.all?(&:blank?)
       hash.delete(integration_class.to_s)
     else

--- a/app/views/shared/_rankee.html.erb
+++ b/app/views/shared/_rankee.html.erb
@@ -1,4 +1,4 @@
-<%= link_to user_url(rankee.user) do %>
+<%= link_to user_url(rankee.user, host: host ) do %>
   <p class="rank"><%= (rankee.index) %></p>
 
   <ul class="details">

--- a/app/views/user_mailer/leaderboard.html.erb
+++ b/app/views/user_mailer/leaderboard.html.erb
@@ -4,7 +4,8 @@
 
   <%- @users.each_with_index do |user, i| -%>
     <li class="rankee">
-      <%= render partial: 'shared/rankee', locals: { rankee: OpenStruct.new(user: user.decorate, index: i + 1) } %>
+      <%= render partial: 'shared/rankee',
+                 locals: { rankee: OpenStruct.new(user: user.decorate, index: i + 1), host: @clan.host } %>
     </li>
   <%- end -%>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -16,7 +16,8 @@
 
   <%- @users.each_with_index do |user, i| -%>
     <li class="rankee">
-      <%= render partial: 'shared/rankee', locals: { rankee: OpenStruct.new(user: user.decorate, index: i + 1) } %>
+      <%= render partial: 'shared/rankee',
+                 locals: { rankee: OpenStruct.new(user: user.decorate, index: i + 1), host: current_clan.host } %>
     </li>
   <%- end -%>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,9 +13,6 @@ Highlander::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Make sure there's a defined host for URL's
-  config.action_mailer.default_url_options = { :host => SITE_ROOT }
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
This follows up https://github.com/envato/highlander/pull/28.

So emails are still broken — it is fundamentally a different problem but it is related to one of the issues highlighted in the previous PR.

The problem is that we weren't using full URL's in a shared view (a view that's being used for both emails and for view rendering). It worked in the application by using relative paths, but gave incomplete links when used in emails.

Now the problem is that emails are using the correct path but we need to be explicit in emails — we don't in controllers.

The change is to explicitly say "hey, we need to show the clan host whenever you show this".

This will fix email sending, too!

/cc @ejoubaud