### PR TITLE
Upgrade Sprockets to 2.12.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'mechanize'
 gem 'octokit'
 gem 'naught'
 gem 'high_voltage'
+gem 'sprockets', '>= 2.12.5'
 
 gem 'exception_notification', github: 'smartinez87/exception_notification'
 gem 'stethoscope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       faraday (~> 0.8, < 0.10)
     simple_oauth (0.3.1)
     slop (3.6.0)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -415,6 +415,7 @@ DEPENDENCIES
   rest-client
   rspec-rails
   sass-rails (~> 4.0.0)
+  sprockets (>= 2.12.5)
   stethoscope
   thin
   thor


### PR DESCRIPTION
Addresses [CVE-2018-3760](http://seclists.org/oss-sec/2018/q2/210)

cc @envato/customer-uptime 